### PR TITLE
Changed OpenCV dependency to 'cv_bridge' to work on hydro and indigo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <build_depend>tf2_bullet</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>opencv2</build_depend>
+  <build_depend>cv_bridge</build_depend>
 
   <run_depend>nav_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -29,7 +29,7 @@
   <run_depend>tf2_bullet</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>eigen</run_depend>
-  <run_depend>opencv2</run_depend>
+  <run_depend>cv_bridge</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
I'd like to be able to bloom this package for both hydro and indigo, and I ran into an issue where "opencv2" is not a valid rosdep key for trusty/indigo:
$ rosdep resolve --rosdistro hydro --os=ubuntu:precise opencv2
# apt

ros-hydro-opencv2
$ rosdep resolve --rosdistro indigo --os=ubuntu:trusty opencv2
ERROR: no rosdep rule for 'opencv2'

Looking at the ROS wiki page for [opencv2](http://wiki.ros.org/opencv2), I'm referred to the cv_bridge package. Changing the build_depend and run_depend to cv_bridge results in a successful rosdep resolution and build on a fresh Precise/Hydro as well as a fresh Trusty/Indigo system.
