### PR TITLE
change combine_grid API

### DIFF
--- a/include/occupancy_grid_utils/combine_grids.h
+++ b/include/occupancy_grid_utils/combine_grids.h
@@ -54,10 +54,10 @@ namespace occupancy_grid_utils
 /// OCCUPIED (100) goes to -1.  Then take the max.  If there are no intersecting cells, value is -1. 
 ///
 /// Assumes all grids lie on the xy plane, and will fail in weird ways if that's not true
-nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids, double resolution);
+void combineGrids(const std::vector<const nav_msgs::OccupancyGrid*>& grids, double resolution, nav_msgs::OccupancyGrid& result);
 
 /// Version of combineGrids that uses the resolution of the first grid.
-nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids);
+void combineGrids (const std::vector<const nav_msgs::OccupancyGrid*>& grids, nav_msgs::OccupancyGrid& result);
 
 
 

--- a/include/occupancy_grid_utils/combine_grids.h
+++ b/include/occupancy_grid_utils/combine_grids.h
@@ -40,7 +40,17 @@
 #ifndef OCCUPANCY_GRID_UTILS_COMBINE_GRIDS_H
 #define OCCUPANCY_GRID_UTILS_COMBINE_GRIDS_H
 
+#include <set>
+#include <iterator>
+
+#include <ros/assert.h>
 #include <nav_msgs/OccupancyGrid.h>
+#include <tf/transform_datatypes.h>
+
+#include <boost/foreach.hpp>
+#include <boost/optional.hpp>
+
+#include <occupancy_grid_utils/coordinate_conversions.h>
 
 namespace occupancy_grid_utils
 {
@@ -54,10 +64,12 @@ namespace occupancy_grid_utils
 /// OCCUPIED (100) goes to -1.  Then take the max.  If there are no intersecting cells, value is -1. 
 ///
 /// Assumes all grids lie on the xy plane, and will fail in weird ways if that's not true
-void combineGrids(const std::vector<const nav_msgs::OccupancyGrid*>& grids, double resolution, nav_msgs::OccupancyGrid& result);
+template<typename ForwardIt>
+void combineGrids(ForwardIt first, ForwardIt last, double resolution, nav_msgs::OccupancyGrid& result);
 
 /// Version of combineGrids that uses the resolution of the first grid.
-void combineGrids (const std::vector<const nav_msgs::OccupancyGrid*>& grids, nav_msgs::OccupancyGrid& result);
+template<typename ForwardIt>
+void combineGrids (ForwardIt first, ForwardIt last, nav_msgs::OccupancyGrid& result);
 
 /* for backward compatibility */
 
@@ -72,6 +84,139 @@ nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyG
 /// you should use combineGrids with raw pointers instead, which saves reference counting
 /// \deprecated
 nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids);
+
+/* util functions */
+template<typename ForwardIt>
+nav_msgs::MapMetaData getCombinedGridInfo (ForwardIt first, ForwardIt last, const double resolution);
+std::set<Cell> intersectingCells (const nav_msgs::MapMetaData& info, const nav_msgs::MapMetaData& info2, const Cell& cell2);
+geometry_msgs::Pose transformPose (const tf::Pose trans, const geometry_msgs::Pose p);
+inline double minX (const nav_msgs::MapMetaData& info);
+inline double maxX (const nav_msgs::MapMetaData& info);
+inline double minY (const nav_msgs::MapMetaData& info);
+inline double maxY (const nav_msgs::MapMetaData& info);
+
+/* templates */
+
+// Get the dimensions of a combined grid
+template<typename ForwardIt>
+nav_msgs::MapMetaData getCombinedGridInfo (ForwardIt first, ForwardIt last, const double resolution)
+{
+  ROS_ASSERT (first != last);
+  nav_msgs::MapMetaData info;
+  info.resolution = resolution;
+  tf::Pose trans;
+  const nav_msgs::OccupancyGrid& first_ref = *first; // needed to support reference_wrapper
+  tf::poseMsgToTF(first_ref.info.origin, trans);
+
+#ifdef GRID_UTILS_GCC_46
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
+  boost::optional<double> min_x, max_x, min_y, max_y;
+  for (ForwardIt grid_it = first; grid_it != last; ++grid_it) {
+    const nav_msgs::OccupancyGrid& grid = *grid_it; // needed to support reference_wrapper
+    nav_msgs::MapMetaData grid_info = grid.info;
+    grid_info.origin = transformPose(trans.inverse(), grid.info.origin);
+    if (!(min_x && *min_x < minX(grid_info)))
+      min_x = minX(grid_info);
+    if (!(min_y && *min_y < minY(grid_info)))
+      min_y = minY(grid_info);
+    if (!(max_x && *max_x > maxX(grid_info)))
+      max_x = maxX(grid_info);
+    if (!(max_y && *max_y > maxY(grid_info)))
+      max_y = maxY(grid_info);
+  }
+  ROS_ASSERT(min_x && max_x && min_y && max_y);
+
+  const double dx = *max_x - *min_x;
+  const double dy = *max_y - *min_y;
+  ROS_ASSERT ((dx > 0) && (dy > 0));
+
+#ifdef GRID_UTILS_GCC_46
+#pragma GCC diagnostic pop
+#endif
+
+  geometry_msgs::Pose pose_in_grid_frame;
+  pose_in_grid_frame.position.x = *min_x;
+  pose_in_grid_frame.position.y = *min_y;
+  pose_in_grid_frame.orientation.w = 1.0;
+  info.origin = transformPose(trans, pose_in_grid_frame);
+  info.height = ceil(dy/info.resolution);
+  info.width = ceil(dx/info.resolution);
+
+  return info;
+}
+
+
+// Main function
+template<typename ForwardIt>
+void combineGrids (ForwardIt first, ForwardIt last, const double resolution, nav_msgs::OccupancyGrid& combined_grid)
+{
+  if(first == last)
+    return;
+
+  combined_grid.info = getCombinedGridInfo(first, last, resolution);
+  combined_grid.data.resize(combined_grid.info.width*combined_grid.info.height);
+  fill(combined_grid.data.begin(), combined_grid.data.end(), -1);
+  ROS_DEBUG_NAMED ("combine_grids", "Combining %zu grids", std::distance(first, last));
+
+  for (ForwardIt grid_it = first; grid_it != last; ++grid_it) {
+    const nav_msgs::OccupancyGrid& grid = *grid_it; // needed to support reference_wrapper
+    for (coord_t x=0; x<(int)grid.info.width; x++) {
+      for (coord_t y=0; y<(int)grid.info.height; y++) {
+        const Cell cell(x, y);
+        const signed char value=grid.data[cellIndex(grid.info, cell)];
+
+        // Only proceed if the value is not unknown
+        if ((value>=0) && (value<=100)) {
+          BOOST_FOREACH (const Cell& intersecting_cell,
+                         intersectingCells(combined_grid.info, grid.info, cell)) {
+            const index_t ind = cellIndex(combined_grid.info, intersecting_cell);
+            combined_grid.data[ind] = std::max(combined_grid.data[ind], value);
+          }
+        }
+      }
+    }
+  }
+
+  ROS_DEBUG_NAMED ("combine_grids", "Done combining grids");
+}
+
+template<typename ForwardIt>
+void combineGrids (ForwardIt first, ForwardIt last, nav_msgs::OccupancyGrid& result)
+{
+  if(first == last)
+    return;
+  const nav_msgs::OccupancyGrid& first_ref = *first; // needed to support reference_wrapper
+  combineGrids(first, last, first_ref.info.resolution, result);
+}
+
+/* inlined util functions */
+
+inline double minX (const nav_msgs::MapMetaData& info)
+{
+  const geometry_msgs::Polygon p=gridPolygon(info);
+  return std::min(p.points[0].x, std::min(p.points[1].x, std::min(p.points[2].x, p.points[3].x)));
+}
+
+inline double maxX (const nav_msgs::MapMetaData& info)
+{
+  const geometry_msgs::Polygon p=gridPolygon(info);
+  return std::max(p.points[0].x, std::max(p.points[1].x, std::max(p.points[2].x, p.points[3].x)));
+}
+
+inline double minY (const nav_msgs::MapMetaData& info)
+{
+  const geometry_msgs::Polygon p=gridPolygon(info);
+  return std::min(p.points[0].y, std::min(p.points[1].y, std::min(p.points[2].y, p.points[3].y)));
+}
+
+inline double maxY (const nav_msgs::MapMetaData& info)
+{
+  const geometry_msgs::Polygon p=gridPolygon(info);
+  return std::max(p.points[0].y, std::max(p.points[1].y, std::max(p.points[2].y, p.points[3].y)));
+}
 
 } // namespace occupancy_grid_utils
 

--- a/include/occupancy_grid_utils/combine_grids.h
+++ b/include/occupancy_grid_utils/combine_grids.h
@@ -107,13 +107,8 @@ nav_msgs::MapMetaData getCombinedGridInfo (ForwardIt first, ForwardIt last, cons
   tf::Pose trans;
   const nav_msgs::OccupancyGrid& first_ref = *first; // needed to support reference_wrapper
   tf::poseMsgToTF(first_ref.info.origin, trans);
-
-#ifdef GRID_UTILS_GCC_46
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#endif
-
   boost::optional<double> min_x, max_x, min_y, max_y;
+
   for (ForwardIt grid_it = first; grid_it != last; ++grid_it) {
     const nav_msgs::OccupancyGrid& grid = *grid_it; // needed to support reference_wrapper
     nav_msgs::MapMetaData grid_info = grid.info;
@@ -132,10 +127,6 @@ nav_msgs::MapMetaData getCombinedGridInfo (ForwardIt first, ForwardIt last, cons
   const double dx = *max_x - *min_x;
   const double dy = *max_y - *min_y;
   ROS_ASSERT ((dx > 0) && (dy > 0));
-
-#ifdef GRID_UTILS_GCC_46
-#pragma GCC diagnostic pop
-#endif
 
   geometry_msgs::Pose pose_in_grid_frame;
   pose_in_grid_frame.position.x = *min_x;

--- a/include/occupancy_grid_utils/combine_grids.h
+++ b/include/occupancy_grid_utils/combine_grids.h
@@ -59,7 +59,19 @@ void combineGrids(const std::vector<const nav_msgs::OccupancyGrid*>& grids, doub
 /// Version of combineGrids that uses the resolution of the first grid.
 void combineGrids (const std::vector<const nav_msgs::OccupancyGrid*>& grids, nav_msgs::OccupancyGrid& result);
 
+/* for backward compatibility */
 
+/// Version of combineGrids that uses shared_ptr
+/// 
+/// you should use combineGrids with raw pointers instead, which saves reference counting
+/// \deprecated
+nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids, double resolution);
+
+/// Version of combineGrids that uses shared_ptr
+/// 
+/// you should use combineGrids with raw pointers instead, which saves reference counting
+/// \deprecated
+nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids);
 
 } // namespace occupancy_grid_utils
 

--- a/src/combine_grids.cpp
+++ b/src/combine_grids.cpp
@@ -44,6 +44,7 @@
 #include <boost/optional.hpp>
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
+#include <boost/make_shared.hpp> /* used only in deprecated functions */
 #include <set>
 #include "gcc_version.h"
 
@@ -61,9 +62,6 @@ using std::multiset;
 using std::set;
 using std::min;
 using std::max;
-
-typedef boost::shared_ptr<nm::OccupancyGrid> GridPtr;
-typedef boost::shared_ptr<nm::OccupancyGrid const> GridConstPtr;
 
 inline Cell point32Cell (const nm::MapMetaData& info, const gm::Point32& p)
 {
@@ -264,6 +262,29 @@ void combineGrids (const vector<const nav_msgs::OccupancyGrid*>& grids, nav_msgs
   combineGrids(grids, grids[0]->info.resolution, result);
 }
 
+/* deprecated functions */
+
+typedef boost::shared_ptr<nm::OccupancyGrid> GridPtr;
+typedef boost::shared_ptr<nm::OccupancyGrid const> GridConstPtr;
+
+nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids, double resolution) {
+  vector<const nav_msgs::OccupancyGrid*> grids_ptrs;
+  grids_ptrs.reserve(grids.size());
+  nav_msgs::OccupancyGrid::Ptr result = boost::make_shared<nm::OccupancyGrid>();
+
+  BOOST_FOREACH (const GridConstPtr& g, grids) {
+    grids_ptrs.push_back(g.get());
+  }
+
+  combineGrids(grids_ptrs, resolution, *result);
+
+  return result;
+}
+
+nav_msgs::OccupancyGrid::Ptr combineGrids(const std::vector<nav_msgs::OccupancyGrid::ConstPtr>& grids) {
+  ROS_ASSERT (!grids.empty());
+  return combineGrids(grids, grids[0]->info.resolution);
+}
 
 } // namespace occupancy_grid_utils
 

--- a/src/combine_grids.cpp
+++ b/src/combine_grids.cpp
@@ -41,7 +41,6 @@
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
 #include <boost/make_shared.hpp> /* used only in deprecated functions */
-#include "gcc_version.h"
 
 namespace occupancy_grid_utils
 {


### PR DESCRIPTION
Hi again,

I have another changelist for parts I use.

The current API for combine grids takes shared_ptr, which is not only theoreticaly and semanticaly wrong as not ownership is passed, but also prevents you completely to safely manage your occupancy grids without shared_ptrs.

I added 2 backward compatible functions using shared pointers.

Cheers,
Jiri
