### PR TITLE
Fix openCV and boost find version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,13 @@ find_package(
 
 ## Add find-modules and define external dependencies
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-find_package(Boost REQUIRED COMPONENTS system python)
+
+find_package(PythonLibs)
+string(REPLACE "." ";" VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
+list(GET VERSION_LIST 0 PYTHONLIBS_VERSION_MAJOR)
+list(GET VERSION_LIST 1 PYTHONLIBS_VERSION_MINOR)
+find_package(Boost REQUIRED COMPONENTS system python${PYTHONLIBS_VERSION_MAJOR}${PYTHONLIBS_VERSION_MINOR})
+
 find_package(Eigen3 REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(Bullet REQUIRED)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -88,7 +88,7 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
               fname + std::string("\"");
       throw std::runtime_error(errmsg);
   }
-  cvtColor(imgColor, img, CV_BGR2GRAY);
+  cvtColor(imgColor, img, cv::COLOR_BGR2GRAY);
 
   // Copy the image data into the map structure
   resp->map.info.width = img.rows;


### PR DESCRIPTION
This version finds the correct version of boost in CMake and change `CV_BGR2GRAY` to `cv::COLOR_BGR2GRAY`